### PR TITLE
Added the ability to upload files and folders using rsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ### HEAD
 
 * Initial move to standalone repo
+* Added the ability to upload assets and plugins using rsync

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,9 @@
 set :application, 'my_app_name'
 set :repo_url, 'git@example.com:me/my_repo.git'
 
-# These folders will be uploaded to the remote using rsync
+# These folders will be uploaded to the remote using rsync. This is useful for
+# files and folders that are not part of the repository.
+#
 # Example:
 # set :upload_folders, [
 # 	'web/app/mu-plugins/', 'web/app/plugins/',
@@ -9,7 +11,6 @@ set :repo_url, 'git@example.com:me/my_repo.git'
 # 	'web/app/themes/*/assets/js/',
 #   'web/app/themes/sage/dist/'
 # ]
-# Be sure to add a trailing slash
 set :upload_folders, [
 	# 'web/app/mu-plugins/', 'web/app/plugins/'
 ]

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,19 @@
 set :application, 'my_app_name'
 set :repo_url, 'git@example.com:me/my_repo.git'
 
+# These folders will be uploaded to the remote using rsync
+# Example:
+# set :upload_folders, [
+# 	'web/app/mu-plugins/', 'web/app/plugins/',
+# 	'web/app/themes/*/assets/css/',
+# 	'web/app/themes/*/assets/js/',
+#   'web/app/themes/sage/dist/'
+# ]
+# Be sure to add a trailing slash
+set :upload_folders, [
+	# 'web/app/mu-plugins/', 'web/app/plugins/'
+]
+
 # Branch options
 # Prompts for the branch name (defaults to current branch)
 #ask :branch, -> { `git rev-parse --abbrev-ref HEAD`.chomp }
@@ -59,3 +72,19 @@ end
 # Note that you need to have WP-CLI installed on your server
 # Uncomment the following line to run it on deploys if needed
 # after 'deploy:publishing', 'deploy:update_option_paths'
+
+namespace :deploy do
+	desc 'Upload compiled stylesheets and javascript files'
+	task :copy_assets do
+		on roles(:app) do |role|
+			run_locally do
+				fetch(:upload_folders).each do |f|
+					execute :rsync, %{-ahvzR --rsh=ssh}, f,
+					  "#{role.user}@#{role.hostname}:#{release_path}"
+				end
+			end
+		end
+	end
+end
+
+after 'deploy:updating', 'deploy:copy_assets'


### PR DESCRIPTION
One thing I missed when using this Capistrano configuration was the ability to upload plugins and compiled assets to the remote as these are normally not part of the code repository, so I've created a simple task that solves this using `rsync`. I'm sure others have run into the similar problems so I decided to share this.
