### PR TITLE
Removing Capistrano version requirement and integrating WPCLI tasks

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -7,6 +7,9 @@ require 'capistrano/deploy'
 # Load tasks from gems
 require 'capistrano/composer'
 
+# Load tasks from Capistrano WPCLI
+require 'capistrano/wpcli'
+
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 # Customize this path to change the location of your custom tasks.
 Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'capistrano', '~> 3.2.0'
+gem 'capistrano'
 gem 'capistrano-composer'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 gem 'capistrano'
 gem 'capistrano-composer'
+
+# Capistrano WPCLI
+gem 'capistrano-wpcli'


### PR DESCRIPTION
Hello. I've made a couple updates to the repo, specifically:
- Removing the Capistrano version requirement (as I was getting SSHKit errors running 3.2.0)
- Integrating the WPCLI deployment and database/upload synchronization commands from the https://github.com/lavmeiker/capistrano-wpcli repo.

Personally, I use the additional WPCLI tools with every project as it's far quicker than using a WordPress plugin for synchronizing environments and I don't see why they shouldn't be included as part of the standard setup.

Please let me know what you think about integrating these updates.